### PR TITLE
Fix missing semicolon

### DIFF
--- a/cypher/add_countries_confederations.cql
+++ b/cypher/add_countries_confederations.cql
@@ -3,7 +3,7 @@ LOAD CSV WITH HEADERS FROM "file:///confederations.csv" AS row
 MERGE (c:Confederation {id: row.urlName})
 ON CREATE SET c.shortName = row.shortName,
               c.region = row.region,
-              c.name = row.name
+              c.name = row.name;
 
 // add countries
 LOAD CSV WITH HEADERS FROM "file:///countries.csv" AS row


### PR DESCRIPTION
Fix missing semicolon in first Cypher statement to avoid syntax error;
```
WITH is required between MERGE and LOAD CSV
```